### PR TITLE
Remove excess backslashes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Phing\\Task\\Ext\\Http\\\\": ""
+      "Phing\\Task\\Ext\\Http\\": ""
     }
   },
   "extra": {


### PR DESCRIPTION
These excess backslashes causes class Phing\Task\Ext\Http\HttpTask not found errors.